### PR TITLE
Allow customisable auth path for all other auth methods

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -32,7 +32,7 @@ module Vault
     # @param [String] path (default: 'token')
     #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def token(new_token, path = 'token')
+    def token(new_token, path: 'token')
       old_token    = client.token
       client.token = new_token
       json = client.get("/v1/auth/#{CGI.escape(path)}/lookup-self")
@@ -68,7 +68,7 @@ module Vault
     # @param [String] path (default: 'app-id')
     #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def app_id(app_id, user_id, options = {}, path = 'app-id')
+    def app_id(app_id, user_id, path: 'app-id', **options)
       payload = { app_id: app_id, user_id: user_id }.merge(options)
       json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
       secret = Secret.decode(json)
@@ -92,7 +92,7 @@ module Vault
     # @param [String] path (default: 'approle')
     #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def approle(role_id, secret_id=nil, path='approle')
+    def approle(role_id, secret_id=nil, path: 'approle')
       payload = { role_id: role_id }
       payload[:secret_id] = secret_id if secret_id
       json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
@@ -119,7 +119,7 @@ module Vault
     # @param [String] path (default: 'userpass')
     #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def userpass(username, password, options = {}, path = 'userpass')
+    def userpass(username, password, path: 'userpass', **options)
       payload = { password: password }.merge(options)
       json = client.post("/v1/auth/#{CGI.escape(path)}/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
@@ -142,7 +142,7 @@ module Vault
     # @param [String] path (default: 'ldap')
     #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def ldap(username, password, options = {}, path = 'ldap')
+    def ldap(username, password, path: 'ldap', **options)
       payload = { password: password }.merge(options)
       json = client.post("/v1/auth/#{CGI.escape(path)}/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
@@ -264,7 +264,7 @@ module Vault
     #   the path were the gcp auth backend is mounted
     #
     # @return [Secret]
-    def gcp(role, jwt, path = 'gcp')
+    def gcp(role, jwt, path: 'gcp')
       payload = { role: role, jwt: jwt }
       json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
       secret = Secret.decode(json)
@@ -292,7 +292,7 @@ module Vault
     #   The path to the auth backend to use for the login procedure.
     #
     # @return [Secret]
-    def tls(pem = nil, path = 'cert')
+    def tls(pem = nil, path: 'cert')
       new_client = client.dup
       new_client.ssl_pem_contents = pem if !pem.nil?
 

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -29,12 +29,13 @@ module Vault
     #
     # @param [String] new_token
     #   the new token to try to authenticate and store on the client
-    #
+    # @param [String] path (default: 'token')
+    #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def token(new_token)
+    def token(new_token, path = 'token')
       old_token    = client.token
       client.token = new_token
-      json = client.get("/v1/auth/token/lookup-self")
+      json = client.get("/v1/auth/#{CGI.escape(path)}/lookup-self")
       secret = Secret.decode(json)
       return secret
     rescue
@@ -64,11 +65,12 @@ module Vault
     # @param [Hash] options
     #   additional options to pass to the authentication call, such as a custom
     #   mount point
-    #
+    # @param [String] path (default: 'app-id')
+    #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def app_id(app_id, user_id, options = {})
+    def app_id(app_id, user_id, options = {}, path = 'app-id')
       payload = { app_id: app_id, user_id: user_id }.merge(options)
-      json = client.post("/v1/auth/app-id/login", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -87,12 +89,13 @@ module Vault
     # @param [String] role_id
     # @param [String] secret_id (default: nil)
     #   It is required when `bind_secret_id` is enabled for the specified role_id
-    #
+    # @param [String] path (default: 'approle')
+    #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def approle(role_id, secret_id=nil)
+    def approle(role_id, secret_id=nil, path='approle')
       payload = { role_id: role_id }
       payload[:secret_id] = secret_id if secret_id
-      json = client.post("/v1/auth/approle/login", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -113,11 +116,12 @@ module Vault
     # @param [Hash] options
     #   additional options to pass to the authentication call, such as a custom
     #   mount point
-    #
+    # @param [String] path (default: 'userpass')
+    #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def userpass(username, password, options = {})
+    def userpass(username, password, options = {}, path = 'userpass')
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/userpass/login/#{encode_path(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -135,11 +139,12 @@ module Vault
     # @param [Hash] options
     #   additional options to pass to the authentication call, such as a custom
     #   mount point
-    #
+    # @param [String] path (default: 'ldap')
+    #   The path to the auth backend to use for the login procedure.
     # @return [Secret]
-    def ldap(username, password, options = {})
+    def ldap(username, password, options = {}, path = 'ldap')
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/ldap/login/#{encode_path(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -255,7 +260,7 @@ module Vault
     # @param [String] role
     # @param [String] jwt
     #   jwt returned by the instance identity metadata, or iam api
-    # @param [String] path optional
+    # @param [String] path (default: 'gcp')
     #   the path were the gcp auth backend is mounted
     #
     # @return [Secret]

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -29,13 +29,12 @@ module Vault
     #
     # @param [String] new_token
     #   the new token to try to authenticate and store on the client
-    # @param [String] path (default: 'token')
-    #   The path to the auth backend to use for the login procedure.
+    #
     # @return [Secret]
-    def token(new_token, path: 'token')
+    def token(new_token)
       old_token    = client.token
       client.token = new_token
-      json = client.get("/v1/auth/#{CGI.escape(path)}/lookup-self")
+      json = client.get("/v1/auth/token/lookup-self")
       secret = Secret.decode(json)
       return secret
     rescue


### PR DESCRIPTION
Clone of https://github.com/hashicorp/vault-ruby/pull/200 upstream.

/cc @zendesk/compute @zendesk/config 